### PR TITLE
On edit CF, use Values instead  of Default  for check/uncheck. Without that CF, valu…

### DIFF
--- a/html/Elements/EditCustomFieldBoolean
+++ b/html/Elements/EditCustomFieldBoolean
@@ -2,11 +2,12 @@
 <input type="checkbox" name="<%$name%>" id="<%$name%>" \
 class="CF-<%$CustomField->id%>-Edit" value="1"<%$checked%> />
 <%INIT>
-my $checked = $Default ? ' checked' : '';
+my $checked = $Values ? ' checked' : '';
 </%INIT>
 <%ARGS>
 $CustomField => undef
 $NamePrefix => undef
 $Name => undef
 $Default => undef
+$Values => undef
 </%ARGS>


### PR DESCRIPTION
Salut Gibus, 

En fait, lorsqu'on édite un ticket. La valeur du CF n'est pas reprise, on se retrouve donc avec le CF systématiquement décoché ce qui provoque la suppression de la valeur du CF lors de la validation du formulaire.